### PR TITLE
Changed the way pagination is handled for the EstatesExports->list() after feedback from Whise

### DIFF
--- a/src/Endpoints/EstatesExports.php
+++ b/src/Endpoints/EstatesExports.php
@@ -11,7 +11,7 @@ namespace Whise\Api\Endpoints;
 
 use Whise\Api\Endpoint;
 use Whise\Api\Request\Request;
-use Whise\Api\Request\CollectionRequest;
+use Whise\Api\Request\Exports\CollectionRequest;
 use Whise\Api\Response\CollectionResponse;
 use Whise\Api\Response\CollectionResponsePaginated;
 

--- a/src/Request/Exports/CollectionRequest.php
+++ b/src/Request/Exports/CollectionRequest.php
@@ -13,33 +13,27 @@ use Whise\Api\Request\CollectionRequest as BaseCollectionRequest;
 
 class CollectionRequest extends BaseCollectionRequest
 {
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getBody(): ?string
-	{
-		if (is_null($this->body))
-		{
-			$this->body = [];
-		}
+    /**
+     * {@inheritdoc}
+     */
+    public function getBody(): ?string
+    {
+        if (is_null($this->body)) {
+            $this->body = [];
+        }
 
-		if (is_array($this->body))
-		{
-			if (!isset($this->body['Page']))
-			{
-				$this->body['Page'] = [];
-			}
-			$this->body['Page']['Limit'] = $this->getPageSize();
-			$this->body['Page']['Offset'] = $this->getPage();
-		}
+        if (is_array($this->body)) {
+            if (!isset($this->body['Page'])) {
+                $this->body['Page'] = [];
+            }
+            $this->body['Page']['Limit'] = $this->getPageSize();
+            $this->body['Page']['Offset'] = $this->getPage();
+        }
 
-		if (is_null($this->body) || is_string($this->body))
-		{
-			return $this->body;
-		}
-		else
-		{
-			return json_encode($this->encode($this->body));
-		}
-	}
+        if (is_null($this->body) || is_string($this->body)) {
+            return $this->body;
+        } else {
+            return json_encode($this->encode($this->body));
+        }
+    }
 }

--- a/src/Request/Exports/CollectionRequest.php
+++ b/src/Request/Exports/CollectionRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the fw4/whise-api library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Whise\Api\Request\Exports;
+
+use Whise\Api\Request\CollectionRequest as BaseCollectionRequest;
+
+class CollectionRequest extends BaseCollectionRequest
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getBody(): ?string
+	{
+		if (is_null($this->body))
+		{
+			$this->body = [];
+		}
+
+		if (is_array($this->body))
+		{
+			if (!isset($this->body['Page']))
+			{
+				$this->body['Page'] = [];
+			}
+			$this->body['Page']['Limit'] = $this->getPageSize();
+			$this->body['Page']['Offset'] = $this->getPage();
+		}
+
+		if (is_null($this->body) || is_string($this->body))
+		{
+			return $this->body;
+		}
+		else
+		{
+			return json_encode($this->encode($this->body));
+		}
+	}
+}

--- a/tests/Request/Exports/CollectionRequestTest.php
+++ b/tests/Request/Exports/CollectionRequestTest.php
@@ -15,34 +15,34 @@ use InvalidArgumentException;
 
 class CollectionRequestTest extends TestCase
 {
-	public function testSetPage(): void
-	{
-		$request = new CollectionRequest('POST', '', []);
-		$request->setPage(1);
+    public function testSetPage(): void
+    {
+        $request = new CollectionRequest('POST', '', []);
+        $request->setPage(1);
 
-		$body = json_decode($request->getBody(), true);
+        $body = json_decode($request->getBody(), true);
 
-		$this->assertEquals([
-								'Page' => [
-									'Limit' => $request->getPageSize(),
-									'Offset' => $request->getPage(),
-								],
-							], $body);
-	}
+        $this->assertEquals([
+                                'Page' => [
+                                    'Limit' => $request->getPageSize(),
+                                    'Offset' => $request->getPage(),
+                                ],
+                            ], $body);
+    }
 
-	public function testSetPageInvalid(): void
-	{
-		$request = new CollectionRequest('POST', '', []);
+    public function testSetPageInvalid(): void
+    {
+        $request = new CollectionRequest('POST', '', []);
 
-		$this->expectException(InvalidArgumentException::class);
-		$request->setPage(-1);
-	}
+        $this->expectException(InvalidArgumentException::class);
+        $request->setPage(-1);
+    }
 
-	public function testSetPageSizeInvalid(): void
-	{
-		$request = new CollectionRequest('POST', '', []);
+    public function testSetPageSizeInvalid(): void
+    {
+        $request = new CollectionRequest('POST', '', []);
 
-		$this->expectException(InvalidArgumentException::class);
-		$request->setPageSize(0);
-	}
+        $this->expectException(InvalidArgumentException::class);
+        $request->setPageSize(0);
+    }
 }

--- a/tests/Request/Exports/CollectionRequestTest.php
+++ b/tests/Request/Exports/CollectionRequestTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the fw4/whise-api library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Whise\Api\Tests\Request\Exports;
+
+use PHPUnit\Framework\TestCase;
+use Whise\Api\Request\Exports\CollectionRequest;
+use InvalidArgumentException;
+
+class CollectionRequestTest extends TestCase
+{
+	public function testSetPage(): void
+	{
+		$request = new CollectionRequest('POST', '', []);
+		$request->setPage(1);
+
+		$body = json_decode($request->getBody(), true);
+
+		$this->assertEquals([
+								'Page' => [
+									'Limit' => $request->getPageSize(),
+									'Offset' => $request->getPage(),
+								],
+							], $body);
+	}
+
+	public function testSetPageInvalid(): void
+	{
+		$request = new CollectionRequest('POST', '', []);
+
+		$this->expectException(InvalidArgumentException::class);
+		$request->setPage(-1);
+	}
+
+	public function testSetPageSizeInvalid(): void
+	{
+		$request = new CollectionRequest('POST', '', []);
+
+		$this->expectException(InvalidArgumentException::class);
+		$request->setPageSize(0);
+	}
+}


### PR DESCRIPTION
I had issues with collecting multiple pages of properties on the EstatesExports->list() function
After asking Whise what was up, Bibek answered: 

'the "offset" behaves as a page number and "limit" as the number of estates you want to get. 
Can you try getting the esattes in this order?'
```
{
    "officeId": , // Add the needed office id_
    "languageIds": [
        "*"
    ],
    "ShowRepresentatives": true,
    "ShowContractDetails": true,
    "ShowCommission": true,
    "page": {
        "limit": 10,       // Number of estate you want in page '0'.
        "offset": 0       // Page Number
    }
}
```

After looking into he CollectionRequest class it should only be 1 line of code that need to be changed.
But the other endpoints still need this class so I created a 2nd class in a new export namespace, and added the parent::getBody() code into this class as well. As calling the parent::getBody() executes the actual CollectionRequest::getBody and overrules the offset again.

I also added a copy of the unit tests and changed the testSetPage to handle this new pagination flow